### PR TITLE
[LDJ] Fix 'Unscramble Touch Screen Keypad in TDJ' for new cards

### DIFF
--- a/signatures/LDJ-signatures.json
+++ b/signatures/LDJ-signatures.json
@@ -144,6 +144,12 @@
                 "adjust": 5,
                 "data": "BA 0C 00 00 00 90",
                 "patchall": true
+            },
+            {
+                "start": 8000000,
+                "signature": "33 D2 48 F7 F3 48 8B 9C 24",
+                "data": "BA 0C 00 00 00",
+                "patchall": true
             }
         ]
     },


### PR DESCRIPTION
Upon creating a new card, the TDJ subscreen pin entry would still scramble when asking to re-enter the pin. This caused confusion for sub poke users, who did not see the scramble.

Tested on 0826 and 1009, on 010 and 012 for both.