### PR TITLE
KFC: automate fake region

### DIFF
--- a/signatures/KFC-signatures.json
+++ b/signatures/KFC-signatures.json
@@ -335,5 +335,11 @@
                 "data": "A7 0C"
             }
         ]
+    },
+    {
+        "type": "hardcoded",
+        "name": "Fake Region",
+        "description": "Forces the game to run as a specific region without altering language, which allows for region-specific content locking. Use Japan for everything to be unlocked.",
+        "id": "kfc_002"
     }
 ]


### PR DESCRIPTION
Implements the automated scan for the Fake Region patch. Confirmed that the output is identical to the existing patches for KFC 0805, 0827, 0910, 0924, 1008. Booted KFC 1008 to verify functionality.